### PR TITLE
Strip slashes from translation keys

### DIFF
--- a/src/Services/Parser.php
+++ b/src/Services/Parser.php
@@ -51,6 +51,9 @@ class Parser
                 return $this->getStrings($file);
             })
             ->flatten()
+            ->map(function (string $string) {
+                return stripslashes($string);
+            })
             ->each(function (string $string) {
                 if ($this->isDotKey($string)) {
                     $this->defaultKeys->push($string);

--- a/tests/LocalizatorTest.php
+++ b/tests/LocalizatorTest.php
@@ -141,4 +141,32 @@ class LocalizatorTest extends TestCase
         // Cleanup.
         self::flushDirectories('lang', 'views');
     }
+
+    /**
+     * @return void
+     */
+    public function testLocalizeCommandWhereKeysAreEscapedWithSlashes(): void
+    {
+        $this->createTestView("{{ __('Amir\'s PC') }} {{ __('Jacob\'s Ladder') }} {{ __('mom\'s spaghetti') }}");
+
+        // Run localize command.
+        $this->artisan('localize')
+            ->assertExitCode(0);
+
+        // Do created locale files exist?
+        self::assertJsonLangFilesExist('en');
+
+        // Do their contents match the expected results?
+        $enJsonContents = $this->getJsonLangContents('en');
+
+        // Did it sort the translation keys like we expected?
+        self::assertSame([
+            'Amir\'s PC' => 'Amir\'s PC',
+            'Jacob\'s Ladder' => 'Jacob\'s Ladder',
+            'mom\'s spaghetti' => 'mom\'s spaghetti',
+        ], $enJsonContents);
+
+        // Cleanup.
+        self::flushDirectories('lang', 'views');
+    }
 }


### PR DESCRIPTION
Because Localizator doesn't evaluate strings (it just collects them) backslashes are evaluated as a character, not an escape.