### PR TITLE
28-integration-in-ci

### DIFF
--- a/src/Commands/LocalizeCommand.php
+++ b/src/Commands/LocalizeCommand.php
@@ -16,7 +16,7 @@ class LocalizeCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'localize {lang?}';
+    protected $signature = 'localize {lang?} {--c|ci : Returns a non zero code when some translations have been added.}';
 
     /**
      * The console command description.
@@ -65,7 +65,7 @@ class LocalizeCommand extends Command
             "\nTranslatable strings have been generated for locale(s): ".implode(', ', $locales)
         );
 
-        return 0;
+        return $this->option("ci") && $parser->foundSomeKeys() ? 1 : 0;
     }
 
     /**

--- a/src/Services/Parser.php
+++ b/src/Services/Parser.php
@@ -69,6 +69,11 @@ class Parser
             });
     }
 
+    public function foundSomeKeys(): bool
+    {
+        return ($this->defaultKeys->count() + $this->jsonKeys->count()) > 0;
+    }
+
     /**
      * @param $key
      * @return bool

--- a/tests/LocalizatorTest.php
+++ b/tests/LocalizatorTest.php
@@ -165,4 +165,28 @@ class LocalizatorTest extends TestCase
         // Cleanup.
         self::flushDirectories('lang', 'views');
     }
+
+    public function testLocalizeCommandReturnsNonZeroCodeWhenCiFlagIsOnAndSomeMissingTranslationsHaveBeenAdded(): void
+    {
+        $this->createTestView("{{ __('Hi mom') }}");
+
+        // Run localize command.
+        $this->artisan('localize', ['--ci' => true])
+            ->assertExitCode(1);
+
+        // Cleanup.
+        self::flushDirectories('lang', 'views');
+    }
+
+    public function testLocalizeCommandReturnsZeroCodeWhenCiFlagIsOnAndNoMissingTranslationsHaveBeenFound(): void
+    {
+        $this->createTestView("");
+
+        // Run localize command.
+        $this->artisan('localize', ['--ci' => true])
+            ->assertExitCode(0);
+
+        // Cleanup.
+        self::flushDirectories('lang', 'views');
+    }
 }

--- a/tests/LocalizatorTest.php
+++ b/tests/LocalizatorTest.php
@@ -189,4 +189,20 @@ class LocalizatorTest extends TestCase
         // Cleanup.
         self::flushDirectories('lang', 'views');
     }
+
+    public function testLocalizeCommandReturnsNonZeroCodeThenZeroCodeIfFileDidNotChangedBetweenTwoRun(): void
+    {
+        $this->createTestView("{{ __('Hi mom') }}");
+
+        // Run localize command.
+        $this->artisan('localize', ['--ci' => true])
+            ->assertExitCode(1);
+
+        // Run localize command.
+        $this->artisan('localize', ['--ci' => true])
+            ->assertExitCode(0);
+
+        // Cleanup.
+        self::flushDirectories('lang', 'views');
+    }
 }


### PR DESCRIPTION
This PR adds a new `--ci` (or `-c`) flag to instruct the command to return a non zero code in case some untranslated keys have been found.