### PR TITLE
add support for newlines and spaces

### DIFF
--- a/src/Services/Parser.php
+++ b/src/Services/Parser.php
@@ -101,7 +101,7 @@ class Parser
      */
     protected function searchPattern(string $function): string
     {
-        return '/('.$function.')\(\h*[\'"](.+)[\'"]\h*[),]/U';
+        return '/(' . $function . ')\([\r\n\s]{0,}\h*[\'"](.+)[\'"]\h*[\r\n\s]{0,}[),]/U';
     }
 
     /**

--- a/tests/LocalizatorTest.php
+++ b/tests/LocalizatorTest.php
@@ -165,4 +165,50 @@ class LocalizatorTest extends TestCase
         // Cleanup.
         self::flushDirectories('lang', 'views');
     }
+
+    public function testLocalizeCommandWithMultilineMessages(): void
+    {
+        $this->createTestView("__(\n'stand with ukraine'\n)");
+
+        // Run localize command.
+        $this->artisan('localize')
+            ->assertExitCode(0);
+
+        // Do created locale files exist?
+        self::assertJsonLangFilesExist('en');
+
+        // Do their contents match the expected results?
+        $enJsonContents = $this->getJsonLangContents('en');
+
+        // Did it sort the translation keys like we expected?
+        self::assertSame([
+            'stand with ukraine' => 'stand with ukraine',
+        ], $enJsonContents);
+
+        // Cleanup.
+        self::flushDirectories('lang', 'views');
+    }
+
+    public function testLocalizeCommandWithMultilineMessagesAndSpaces(): void
+    {
+        $this->createTestView("{{ __(\n   'stand with ukraine'   \n) }}");
+
+        // Run localize command.
+        $this->artisan('localize')
+            ->assertExitCode(0);
+
+        // Do created locale files exist?
+        self::assertJsonLangFilesExist('en');
+
+        // Do their contents match the expected results?
+        $enJsonContents = $this->getJsonLangContents('en');
+
+        // Did it sort the translation keys like we expected?
+        self::assertSame([
+            'stand with ukraine' => 'stand with ukraine',
+        ], $enJsonContents);
+
+        // Cleanup.
+        self::flushDirectories('lang', 'views');
+    }
 }


### PR DESCRIPTION
When I wrote at #34, I once created a PR with the customized Search Pattern.

With this it is now possible to search for strings in the JS code if they are multiline.

Example:

`
{{
    $t(
        "A message like stand with ukraine or something else"
    )
}}
`

I think this is only a issue with a formater like prettier.