### PR TITLE
Added an option to remove missing keys

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,14 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         php: [ 7.2.5, 8.0 ]
-        laravel: [ 6.*, 8.*, 9.0 ]
+        laravel: [ 6.*, 8.*, ^9.33 ]
         testbench: [ ^4.0, ^6.6, ^7.0 ]
         stability: [ prefer-lowest, prefer-stable ]
         exclude:
           - php: 7.2.5
             laravel: 8.*
           - php: 7.2.5
-            laravel: 9.0
+            laravel: ^9.33
           - php: 7.2.5
             testbench: ^6.6
           - php: 7.2.5
@@ -30,9 +30,9 @@ jobs:
             testbench: ^4.0
           - laravel: 8.*
             testbench: ^7.0
-          - laravel: 9.0
+          - laravel: ^9.33
             testbench: ^4.0
-          - laravel: 9.0
+          - laravel: ^9.33
             testbench: ^6.6
 
     name: php-${{ matrix.php }} - laravel-${{ matrix.laravel }} - testbench-${{ matrix.testbench }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ In this case translation strings will be generated for the language specified in
 
 > Note: Strings you have already translated will not be overwritten.
 
+### Remove Missing Keys
+
+By default, the strings inside the locale files will be preserved even if they are not present the next time you run the localize command.
+If you want to remove those keys that are not present in your files anymore you can append the --remove-missing option to the localize command.
+``` bash
+php artisan localize --remove-missing
+```
 ### Key Sorting
 
 By default, the strings generated inside those JSON files will be sorted alphabetically by their keys.

--- a/src/Collections/DefaultKeyCollection.php
+++ b/src/Collections/DefaultKeyCollection.php
@@ -24,4 +24,13 @@ class DefaultKeyCollection extends Translatable
     {
         return parent::merge(Arr::dot($items));
     }
+
+    /**
+     * @param mixed $items
+     * @return static
+     */
+    public function intersectByKeys($items): self
+    {
+        return new DefaultKeyCollection(collect(Arr::dot($this))->intersectByKeys($items));
+    }
 }

--- a/src/Collections/DefaultKeyCollection.php
+++ b/src/Collections/DefaultKeyCollection.php
@@ -31,6 +31,6 @@ class DefaultKeyCollection extends Translatable
      */
     public function intersectByKeys($items): self
     {
-        return new DefaultKeyCollection(collect(Arr::dot($this))->intersectByKeys($items));
+        return new self(collect(Arr::dot($this))->intersectByKeys($items));
     }
 }

--- a/src/Commands/LocalizeCommand.php
+++ b/src/Commands/LocalizeCommand.php
@@ -41,7 +41,7 @@ class LocalizeCommand extends Command
         $locales = $this->getLocales();
         $progressBar = $this->output->createProgressBar(count($locales));
 
-        $this->info('Localizing: ' . implode(', ', $locales));
+        $this->info('Localizing: '.implode(', ', $locales));
 
         $parser->parseKeys();
 
@@ -67,7 +67,7 @@ class LocalizeCommand extends Command
         $progressBar->finish();
 
         $this->info(
-            "\nTranslatable strings have been generated for locale(s): " . implode(', ', $locales)
+            "\nTranslatable strings have been generated for locale(s): ".implode(', ', $locales)
         );
 
         return 0;

--- a/src/Commands/LocalizeCommand.php
+++ b/src/Commands/LocalizeCommand.php
@@ -16,7 +16,7 @@ class LocalizeCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'localize {lang?}';
+    protected $signature = 'localize {lang?} {--remove-missing}';
 
     /**
      * The console command description.
@@ -41,7 +41,7 @@ class LocalizeCommand extends Command
         $locales = $this->getLocales();
         $progressBar = $this->output->createProgressBar(count($locales));
 
-        $this->info('Localizing: '.implode(', ', $locales));
+        $this->info('Localizing: ' . implode(', ', $locales));
 
         $parser->parseKeys();
 
@@ -53,7 +53,12 @@ class LocalizeCommand extends Command
             $progressBar->setMessage("Localizing {$locale}...");
 
             foreach ($this->getTypes() as $type) {
-                $localizator->localize($parser->getKeys($locale, $type), $type, $locale);
+                $localizator->localize(
+                    $parser->getKeys($locale, $type),
+                    $type,
+                    $locale,
+                    $this->option('remove-missing')
+                );
             }
 
             $progressBar->advance();
@@ -62,7 +67,7 @@ class LocalizeCommand extends Command
         $progressBar->finish();
 
         $this->info(
-            "\nTranslatable strings have been generated for locale(s): ".implode(', ', $locales)
+            "\nTranslatable strings have been generated for locale(s): " . implode(', ', $locales)
         );
 
         return 0;

--- a/tests/LocalizatorTest.php
+++ b/tests/LocalizatorTest.php
@@ -302,7 +302,7 @@ PHP;
 
         $this->createTestDefaultLangFile([
             'missingstring' => 'Missing',
-            'name' => 'Name'
+            'name' => 'Name',
         ], 'app', 'en');
         $this->createTestJsonLangFile([
             'Login' => 'Login',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,17 +24,6 @@ class TestCase extends Orchestra
     }
 
     /**
-     * This method is called after the last test of this test class is run.
-     *
-     * @return void
-     */
-    public static function tearDownAfterClass(): void
-    {
-        // Flush one last time after all tests have finished running.
-        self::flushDirectories('lang', 'views');
-    }
-
-    /**
      * Get package providers.
      *
      * @param \Illuminate\Foundation\Application|\Illuminate\Contracts\Foundation\Application $app


### PR DESCRIPTION
I added an option that will remove keys that are not present when you run the localize command.
This was mentioned in the #26 and @amiranagram self-assigned it. I was in need of the feature so i impemented it. Hopefully it can be of use to someone else :)

### Contribution rules
- [x] Follow the PSR-2 Coding Standard]
- [x] Add tests!
- [x] Document any change in behaviour 
- [x] Consider our release cycle
- [x] One pull request per feature 
- [x] Send coherent history