### PR TITLE
Get correct lang path in Laravel 9.X

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,12 +1,20 @@
 <?php
 
-if (! function_exists('lang_path')) {
+if (!function_exists('lang_path')) {
     /**
      * @param string $path
      * @return string
      */
     function lang_path($path = '')
     {
-        return resource_path('lang'.($path !== '' ? DIRECTORY_SEPARATOR.$path : ''));
+        if (
+            function_exists('app') &&
+            method_exists(app(), 'langPath') &&
+            is_dir(app()->langPath())
+        ) {
+            return app()->langPath($path);
+        } else {
+            return resource_path('lang' . ($path !== '' ? DIRECTORY_SEPARATOR . $path : ''));
+        }
     }
 }


### PR DESCRIPTION
Get correct lang path in Laravel 9.X - Check if it is possible to use the recomended method (https://laravel.com/docs/9.x/upgrade#the-lang-directory) else use legacy resource_path method.