### PR TITLE
Added --force option to the localize command

### DIFF
--- a/src/Commands/LocalizeCommand.php
+++ b/src/Commands/LocalizeCommand.php
@@ -16,7 +16,7 @@ class LocalizeCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'localize {lang?} {--remove-missing}';
+    protected $signature = 'localize {lang?} {--remove-missing} {--force}';
 
     /**
      * The console command description.


### PR DESCRIPTION
The Localize command implements the ConfirmableTrait but does not have a --force option.
This makes it impossible to use the command programmatically and bypass the "Do you really wish to run this command?" Which you are supposed to be able to do using the --force option.

I did not add any tests since i did not manage to change the environment to production to force the question "Do you really wish to run this command? " therefore i could not create any assertions.

But it does work and it is a minor change that only implements a trait. Just an option no further code changes.  All the previous tests pass as expected.