### PR TITLE
Support Laravel 11

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: tests
 
-on: [ pull_request ]
+on:
+  push:
+    branches:
+      - master
+      - 0.x
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:
@@ -9,57 +15,24 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 7.2.5, 8.0, 8.1 ]
-        laravel: [ 6.*, 8.*, ^9.33, 10.* ]
-        testbench: [ ^4.0, ^6.6, ^7.0, ^8.0 ]
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        laravel: [ '8.0', '9.33', '10.0', '11.0' ]
         stability: [ prefer-lowest, prefer-stable ]
         exclude:
-          - php: 7.2.5
-            laravel: 10.*
-          - php: 8.0
-            laravel: 10.*
-          - php: 8.1
-            laravel: 6.*
-          - php: 7.2.5
-            laravel: 8.*
-          - php: 7.2.5
-            laravel: ^9.33
-          - php: 7.2.5
-            testbench: ^8.0
-          - php: 7.2.5
-            testbench: ^6.6
-          - php: 7.2.5
-            testbench: ^7.0
-          - php: 8.0
-            testbench: ^8.0
-          - php: 8.1
-            testbench: ^4.0
-          - php: 8.1
-            testbench: ^6.6
-          - php: 8.1
-            testbench: ^7.0
-          - laravel: 6.*
-            testbench: ^6.6
-          - laravel: 6.*
-            testbench: ^7.0
-          - laravel: 8.*
-            testbench: ^4.0
-          - laravel: 8.*
-            testbench: ^7.0
-          - laravel: 8.*
-            testbench: ^8.0
-          - laravel: ^9.33
-            testbench: ^4.0
-          - laravel: ^9.33
-            testbench: ^6.6
-          - laravel: ^9.33
-            testbench: ^8.0
+          - php: '8.0'
+            laravel: '10.0'
+          - php: '8.0'
+            laravel: '11.0'
+          - php: '8.1'
+            laravel: '11.0'
+          - laravel: '8.0'
+            stability: prefer-lowest
 
-    name: php-${{ matrix.php }} - laravel-${{ matrix.laravel }} - testbench-${{ matrix.testbench }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: php-${{ matrix.php }} - laravel-${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -75,8 +48,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer require "illuminate/support:^${{ matrix.laravel }}" --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --no-coverage

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: 0.x
 

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
     "require": {
         "php": "^7.2.5|^8.0",
         "ext-json": "*",
-        "illuminate/config": "^6.0|^8.0|^9.0|^10.0",
-        "illuminate/console": "^6.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^6.0|^8.0|^9.0|^10.0",
-        "illuminate/filesystem": "^6.0|^8.0|^9.0|^10.0",
-        "symfony/finder": "^4.4|^5.1|^6.0"
+        "illuminate/config": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/console": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/filesystem": "^8.0|^9.0|^10.0|^11.0",
+        "symfony/finder": "^5.1|^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^4.0|^6.6|^7.0|^8.0",
-        "phpunit/phpunit": "^8.5|^9.5"
+        "orchestra/testbench": "^6.6|^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^9.5|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds support for Laravel 11

It also updates the workflow by:
- updating `actions/checkout` version
- set `illuminate/support` version, which automatically select the proper laravel version (no need to define `orchestra/testbench` version)
- add php 8.3 and remove old 7.2 version
- remove old laravel 6 version

I hope this can help you maintaining this useful package!